### PR TITLE
Fix for issue #12; "Copy Extended" was only copying blank lines.

### DIFF
--- a/scripts/console_generator.py
+++ b/scripts/console_generator.py
@@ -19,6 +19,7 @@ class LogT(object):
         self.log.level = level
         self.log.name = name
         self.log.file = '/home/tallest/workspaces/gir/src/' + filename
+        self.log.line = line
         self.log.function = function
 
     def generate(self):
@@ -33,6 +34,8 @@ class LogT(object):
 
 
 log_templates = [
+    LogT('typewriter/src/linebreak.cpp', 'break_lines', 50,
+         '/typewriter/output', Log.DEBUG, "Breaking\nLines."),
     LogT('taco_system/src/taste_evaluator.cpp', 'calc_spicy', 225,
          '/taste/taco_manager', Log.WARN, lambda : ('sample exceeds max capsaicin levels (%.2f)' % random.uniform(12, 19))),
     LogT('squirrel_observer/src/distraction.cpp', 'handle_distraction', 891,
@@ -51,6 +54,6 @@ rospy.init_node('console_pub')
 rosout = rospy.Publisher('/rosout', Log, queue_size=0)
 
 while not rospy.is_shutdown():
-    rospy.sleep(random.uniform(0.01, 1.0))
+    rospy.sleep(random.uniform(0.001, 0.1))
     msg = random.choice(log_templates).generate()
     rosout.publish(msg)

--- a/src/log_database_proxy_model.cpp
+++ b/src/log_database_proxy_model.cpp
@@ -254,6 +254,7 @@ QVariant LogDatabaseProxyModel::data(
     // if we're being queried for anything else.
     case Qt::DisplayRole:
     case Qt::ToolTipRole:
+    case ExtendedLogRole:
       break;
     case Qt::ForegroundRole:
       if (colorize_logs_) {


### PR DESCRIPTION
A switch statement was missing a case, causing the function that should've done the copying to exit early.

I also noticed that the console_generator.py script wasn't setting line numbers properly or logging any DEBUG messages, so I set those and made it a bit faster just so that you don't have to wait as long to get data while debugging things.