### PR TITLE
Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,16 @@ cmake_minimum_required(VERSION 2.8.3)
 project(swri_console)
 
 find_package(catkin REQUIRED COMPONENTS rosbag_storage roscpp rosgraph_msgs)
-find_package(Qt4 REQUIRED)
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5Widgets REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS Qt4
   CATKIN_DEPENDS rosbag_storage roscpp rosgraph_msgs
 )
 
-include(${QT_USE_FILE})
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(include 
   ${catkin_INCLUDE_DIRS} 
   ${QT_INCLUDE_DIR} )
@@ -42,9 +43,9 @@ file (GLOB SRC_FILES
   src/log_database_proxy_model.cpp
   src/ros_thread.cpp
   src/settings_keys.cpp)
-qt4_add_resources(RCC_SRCS resources/images.qrc)
-qt4_wrap_ui(SRC_FILES ${UI_FILES})
-qt4_wrap_cpp(SRC_FILES ${HEADER_FILES})
+qt5_add_resources(RCC_SRCS resources/images.qrc)
+qt5_wrap_ui(SRC_FILES ${UI_FILES})
+qt5_wrap_cpp(SRC_FILES ${HEADER_FILES})
 
 add_executable(swri_console ${HEADER_FILES} ${SRC_FILES} ${RCC_SRCS} src/main.cpp)
 target_link_libraries(swri_console

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,20 @@ catkin_package(
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 include_directories(include 
   ${catkin_INCLUDE_DIRS} 
-  ${QT_INCLUDE_DIR} )
-add_definitions(${QT_DEFINITIONS})
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Gui_INCLUDE_DIRS}
+  ${Qt5Widgets_INCLUDE_DIRS}
+)
+add_definitions(
+  ${Qt5Core_DEFINITIONS}
+  ${Qt5Gui_DEFINITIONS}
+  ${Qt5Widgets_DEFINITIONS}
+)
 
 set(QT_USE_QTCORE TRUE)
 set(QT_USE_QTGUI TRUE)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
 
 # Build mapviz node
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -49,7 +58,9 @@ qt5_wrap_cpp(SRC_FILES ${HEADER_FILES})
 
 add_executable(swri_console ${HEADER_FILES} ${SRC_FILES} ${RCC_SRCS} src/main.cpp)
 target_link_libraries(swri_console
-  ${QT_LIBRARIES}
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Gui_LIBRARIES}
+  ${Qt5Widgets_LIBRARIES}
   ${catkin_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/include/swri_console/console_master.h
+++ b/include/swri_console/console_master.h
@@ -51,7 +51,7 @@ class ConsoleMaster : public QObject
   Q_OBJECT;
 
  public:  
-  ConsoleMaster();
+  ConsoleMaster(int argc, char** argv);
   virtual ~ConsoleMaster();
 
  public Q_SLOTS:

--- a/include/swri_console/console_window.h
+++ b/include/swri_console/console_window.h
@@ -31,7 +31,7 @@
 #ifndef SWRI_CONSOLE_CONSOLE_WINDOW_H_
 #define SWRI_CONSOLE_CONSOLE_WINDOW_H_
 
-#include <QtGui/QMainWindow>
+#include <QtWidgets/QMainWindow>
 #include <QColor>
 #include <QPushButton>
 #include <QSettings>

--- a/include/swri_console/ros_thread.h
+++ b/include/swri_console/ros_thread.h
@@ -43,7 +43,7 @@ namespace swri_console
   {
     Q_OBJECT
   public:
-    RosThread();
+    RosThread(int argc, char** argv);
     /*
      * Shuts down ROS and causes the thread to exit.
      */

--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <exec_depend>libqt4</exec_depend>
-  <depend>libqt4-dev</depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
   <depend>rosbag_storage</depend>
   <depend>roscpp</depend>
   <depend>rosgraph_msgs</depend>

--- a/src/console_master.cpp
+++ b/src/console_master.cpp
@@ -37,8 +37,8 @@
 
 namespace swri_console
 {
-ConsoleMaster::ConsoleMaster()
-  :
+ConsoleMaster::ConsoleMaster(int argc, char** argv):
+  ros_thread_(argc, argv),
   connected_(false),
   window_font_(QFont("Ubuntu Mono", 9))
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
   QCoreApplication::setOrganizationDomain("swri.org");
   QCoreApplication::setApplicationName("SwRI Console");
   
-  swri_console::ConsoleMaster master;
+  swri_console::ConsoleMaster master(argc, argv);
   master.createNewWindow();
   app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
   int result = app.exec();

--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -33,12 +33,11 @@
 
 using namespace swri_console;
 
-RosThread::RosThread() :
+RosThread::RosThread(int argc, char** argv) :
   is_connected_(false),
   is_running_(true)
 {
-  int argc = QCoreApplication::argc();
-  ros::init(argc, QCoreApplication::argv(), "swri_console",
+  ros::init(argc, argv, "swri_console",
             ros::init_options::AnonymousName |
             ros::init_options::NoRosout);
 }


### PR DESCRIPTION
I'm working on getting swri_console ready for Ubuntu 16.04 and ROS Kinetic. Qt4 doesn't play nicely with the version of Boost in 16.04, so the easiest path forward is to upgrade to Qt5. This compiles on 14.04/Indigo and it passes a prerelease test for 16.04/Kinetic. I've run it under Indigo, but haven't tested it extensively. I'd like to get some people to soak test this, and then merge it in so we can do a kinetic release.