### PR TITLE
Change logger levels from within swri_console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ crashlytics-build.properties
 *.dSYM/
 
 # Created by .ignore support plugin (hsz.mobi)
+cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,6 @@ msg/_*.py
 /cfg/*.py
 
 # Ignore generated docs
-*.dox
 *.wikidoc
 
 # eclipse stuff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,17 @@ file (GLOB HEADER_FILES
   include/swri_console/console_master.h
   include/swri_console/console_window.h
   include/swri_console/log_database.h
+  include/swri_console/node_click_handler.h
   include/swri_console/node_list_model.h
   include/swri_console/log_database_proxy_model.h
-  include/swri_console/ros_thread.h)
+  include/swri_console/ros_thread.h
+  include/swri_console/settings_keys.h)
 file (GLOB SRC_FILES
   src/bag_reader.cpp
   src/console_master.cpp
   src/console_window.cpp
   src/log_database.cpp
+  src/node_click_handler.cpp
   src/node_list_model.cpp
   src/log_database_proxy_model.cpp
   src/ros_thread.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS rosbag_storage roscpp rosgraph_msgs)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Gui REQUIRED)
 find_package(Qt5Widgets REQUIRED)
+find_package(Boost COMPONENTS chrono REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -17,6 +18,7 @@ include_directories(include
   ${Qt5Core_INCLUDE_DIRS}
   ${Qt5Gui_INCLUDE_DIRS}
   ${Qt5Widgets_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 add_definitions(
   ${Qt5Core_DEFINITIONS}
@@ -64,7 +66,9 @@ target_link_libraries(swri_console
   ${Qt5Core_LIBRARIES}
   ${Qt5Gui_LIBRARIES}
   ${Qt5Widgets_LIBRARIES}
-  ${catkin_LIBRARIES})
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}

--- a/include/swri_console/console_window.h
+++ b/include/swri_console/console_window.h
@@ -37,6 +37,8 @@
 #include <QSettings>
 #include "ui_console_window.h"
 
+#include "node_click_handler.h"
+
 namespace swri_console
 {
 class LogDatabase;
@@ -106,6 +108,7 @@ private:
   LogDatabase *db_;
   LogDatabaseProxyModel *db_proxy_;
   NodeListModel *node_list_model_;
+  NodeClickHandler *node_click_handler_;
 };  // class ConsoleWindow
 }  // namespace swri_console
 

--- a/include/swri_console/node_click_handler.h
+++ b/include/swri_console/node_click_handler.h
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -34,14 +34,23 @@
 #include <QObject>
 #include <QEvent>
 
+#include <ros/ros.h>
+
 namespace swri_console
 {
   class NodeClickHandler : public QObject
   {
     Q_OBJECT
 
+  public Q_SLOTS:
+    void logLevelClicked();
+
   protected:
     bool eventFilter(QObject* obj, QEvent* event);
+
+  private:
+    ros::NodeHandle nh_;
+    std::string node_name_;
   };
 }
 

--- a/include/swri_console/node_click_handler.h
+++ b/include/swri_console/node_click_handler.h
@@ -31,10 +31,19 @@
 #ifndef SWRI_CONSOLE_NODE_CLICK_HANDLER_H
 #define SWRI_CONSOLE_NODE_CLICK_HANDLER_H
 
+#include <vector>
+
+#include <boost/thread.hpp>
+
+#include <QContextMenuEvent>
 #include <QObject>
 #include <QEvent>
+#include <QFuture>
+#include <QListView>
+#include <QMenu>
 
 #include <ros/ros.h>
+#include <ros/service_client.h>
 
 namespace swri_console
 {
@@ -49,8 +58,49 @@ namespace swri_console
     bool eventFilter(QObject* obj, QEvent* event);
 
   private:
+    /**
+     * Used by callService() to actually call the service in another thread.
+     */
+    template <class T> void callServiceWorker(ros::ServiceClient& client, T* service, bool* success)
+    {
+      *success = client.call(*service);
+    }
+
+    /**
+     * Attempts to call a ROS service.  Will time out and return false if the service call
+     * does not return within a specified time.
+     *
+     * This is *so* ugly, but some sort of hack like this is necessary for keeping the UI responsive;
+     * ROS service clients do not have any built-in timeout mechanism, so we have to wrap our own
+     * around the service call.  If we don't, a call to a hanged node could spin forever.
+     * @tparam T Type of the ROS service
+     * @param client An initialized ros::ServiceClient
+     * @param service An instance of the ROS service
+     * @param timeout_secs The number of seconds to wait before timing out
+     * @return true if the service call completed successfully, otherwise false
+     */
+    template <class T> bool callService(ros::ServiceClient& client, T& service, int timeout_secs = 5)
+    {
+      bool success = false;
+      boost::thread svc_thread(&NodeClickHandler::callServiceWorker<T>, this, client, &service, &success);
+
+      if (svc_thread.try_join_for(boost::chrono::seconds(timeout_secs)))
+      {
+        return success;
+      }
+      return false;
+    }
+
+    bool showContextMenu(QListView* list, QContextMenuEvent* event);
+    QMenu* createMenu(const QString& logger_name, const QString& current_level);
+
     ros::NodeHandle nh_;
     std::string node_name_;
+    std::vector<std::string> all_loggers_;
+
+    static const std::string ALL_LOGGERS;
+    static const std::string GET_LOGGERS_SVC;
+    static const std::string SET_LOGGER_LEVEL_SVC;
   };
 }
 

--- a/include/swri_console/node_click_handler.h
+++ b/include/swri_console/node_click_handler.h
@@ -84,8 +84,7 @@ namespace swri_console
       bool success = false;
       boost::thread svc_thread(&NodeClickHandler::callServiceWorker<T>, this, client, &service, &success);
 
-      if (svc_thread.try_join_for(boost::chrono::seconds(timeout_secs)))
-      {
+      if (svc_thread.try_join_for(boost::chrono::seconds(timeout_secs))) {
         return success;
       }
       svc_thread.interrupt();

--- a/include/swri_console/node_click_handler.h
+++ b/include/swri_console/node_click_handler.h
@@ -1,0 +1,48 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef SWRI_CONSOLE_NODE_CLICK_HANDLER_H
+#define SWRI_CONSOLE_NODE_CLICK_HANDLER_H
+
+#include <QObject>
+#include <QEvent>
+
+namespace swri_console
+{
+  class NodeClickHandler : public QObject
+  {
+    Q_OBJECT
+
+  protected:
+    bool eventFilter(QObject* obj, QEvent* event);
+  };
+}
+
+#endif //SWRI_CONSOLE_NODE_CLICK_HANDLER_H

--- a/include/swri_console/node_click_handler.h
+++ b/include/swri_console/node_click_handler.h
@@ -88,6 +88,7 @@ namespace swri_console
       {
         return success;
       }
+      svc_thread.interrupt();
       return false;
     }
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
+  <depend>boost</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/src/console_window.cpp
+++ b/src/console_window.cpp
@@ -60,7 +60,8 @@ ConsoleWindow::ConsoleWindow(LogDatabase *db)
   QMainWindow(),
   db_(db),
   db_proxy_(new LogDatabaseProxyModel(db)),
-  node_list_model_(new NodeListModel(db))
+  node_list_model_(new NodeListModel(db)),
+  node_click_handler_(new NodeClickHandler())
 {
   ui.setupUi(this); 
 
@@ -124,6 +125,8 @@ ConsoleWindow::ConsoleWindow(LogDatabase *db)
                                 const QItemSelection &)),
     this,
     SLOT(nodeSelectionChanged()));
+
+  ui.nodeList->installEventFilter(node_click_handler_);
 
   QObject::connect(
     ui.checkDebug, SIGNAL(toggled(bool)),

--- a/src/node_click_handler.cpp
+++ b/src/node_click_handler.cpp
@@ -1,0 +1,51 @@
+// *****************************************************************************
+//
+// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL Southwest Research Institute® BE LIABLE 
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// *****************************************************************************
+
+#include <swri_console/node_click_handler.h>
+
+#include <ros/ros.h>
+
+namespace swri_console
+{
+  bool NodeClickHandler::eventFilter(QObject* obj, QEvent* event)
+  {
+    switch (event->type()) {
+      case QEvent::ContextMenu:
+        ROS_INFO("Context menu.");
+        break;
+
+      default:
+        ROS_DEBUG("Other event.");
+        break;
+    }
+    return false;
+  }
+}
+

--- a/src/node_click_handler.cpp
+++ b/src/node_click_handler.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2015, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,23 +29,126 @@
 // *****************************************************************************
 
 #include <swri_console/node_click_handler.h>
+#include <swri_console/node_list_model.h>
 
 #include <ros/ros.h>
+#include <roscpp/GetLoggers.h>
+#include <roscpp/SetLoggerLevel.h>
+
+#include <QContextMenuEvent>
+#include <QListView>
+#include <QMenu>
+#include <QTextStream>
 
 namespace swri_console
 {
   bool NodeClickHandler::eventFilter(QObject* obj, QEvent* event)
   {
+    QContextMenuEvent* context_event;
     switch (event->type()) {
       case QEvent::ContextMenu:
-        ROS_INFO("Context menu.");
+        context_event = static_cast<QContextMenuEvent*>(event);
         break;
-
       default:
-        ROS_DEBUG("Other event.");
-        break;
+        // Pass through all other events
+        return QObject::eventFilter(obj, event);
     }
+
+    // First, make sure we clicked on the list and have an item in the list
+    // under the mouse cursor.
+    QListView* list = static_cast<QListView*>(obj);
+    if (list == NULL) {
+      return false;
+    }
+
+    QModelIndex index = list->indexAt(context_event->pos());
+    if (!index.isValid()) {
+      return false;
+    }
+
+    // Now get the node name that was clicked on and make a service call to
+    // get all of the loggers registered for that node.
+    NodeListModel* model = static_cast<NodeListModel*>(list->model());
+    node_name_ = model->nodeName(index);
+
+    std::string service_name = node_name_ + "/get_loggers";
+    ros::ServiceClient client = nh_.serviceClient<roscpp::GetLoggers>(service_name);
+    if (!client.waitForExistence(ros::Duration(2.0)))
+    {
+      ROS_WARN("Timed out while waiting for service at %s.", service_name.c_str());
+      return false;
+    }
+
+    roscpp::GetLoggers srv;
+
+    QMenu menu(list);
+    QAction* label = menu.addAction(QString::fromStdString(node_name_ + " loggers:"));
+    label->setDisabled(true);
+
+    ROS_DEBUG("Getting loggers for %s...", node_name_.c_str());
+    if (client.call(srv))
+    {
+      roscpp::Logger logger;
+      Q_FOREACH(logger, srv.response.loggers)
+      {
+        ROS_DEBUG("Log level for %s is %s", logger.name.c_str(), logger.level.c_str());
+        QString action_label;
+        QString logger_name = QString::fromStdString(logger.name);
+        QTextStream stream(&action_label);
+        stream << logger.name.c_str() << " (" << QString::fromStdString(logger.level).toUpper() << ")";
+
+        QMenu* nodeMenu = new QMenu(action_label);
+        menu.addMenu(nodeMenu);
+
+        QAction* action = nodeMenu->addAction("DEBUG", this, SLOT(logLevelClicked()));
+        action->setData(logger_name);
+        action = nodeMenu->addAction("INFO", this, SLOT(logLevelClicked()));
+        action->setData(logger_name);
+        action = nodeMenu->addAction("WARN", this, SLOT(logLevelClicked()));
+        action->setData(logger_name);
+        action = nodeMenu->addAction("ERROR", this, SLOT(logLevelClicked()));
+        action->setData(logger_name);
+        action = nodeMenu->addAction("FATAL", this, SLOT(logLevelClicked()));
+        action->setData(logger_name);
+      }
+    }
+    else
+    {
+      ROS_WARN("Service call to get loggers failed.");
+    }
+
+    menu.exec(context_event->globalPos());
+
     return false;
+  }
+
+  void NodeClickHandler::logLevelClicked()
+  {
+    QAction* action = static_cast<QAction*>(sender());
+
+    std::string logger = action->data().toString().toStdString();
+    std::string level = action->text().toStdString();
+    ROS_DEBUG("Setting log level for %s/%s to %s", node_name_.c_str(), logger.c_str(), level.c_str());
+
+    std::string service_name = node_name_ + "/set_logger_level";
+
+    ros::ServiceClient client = nh_.serviceClient<roscpp::SetLoggerLevel>(service_name);
+    if (!client.waitForExistence(ros::Duration(2.0)))
+    {
+      ROS_WARN("Timed out while waiting for service at %s.", service_name.c_str());
+      return;
+    }
+    roscpp::SetLoggerLevel srv;
+    srv.request.level = level;
+    srv.request.logger = logger;
+    if (client.call(srv))
+    {
+      ROS_DEBUG("Set logger level.");
+    }
+    else
+    {
+      ROS_WARN("Service call to %s failed.", service_name.c_str());
+    }
   }
 }
 


### PR DESCRIPTION
This adds the ability to change a node's logger levels by right-clicking on it.

There are still a few things I should work out:
- [x] Should have an option to set the logging level for every logger in a node
- [x] Opening the menu and setting the logging level both make service calls, and there's no easy way to make a service call time out, which means a call to a dead node could hang for a very long time; probably will have to do something ugly with a timer in another thread to cancel hanged service calls
- ~~Only works for a single node at a time; would be nice if it could work on a selected range~~
- ~~Since you have to be able to right-click on a node in the list, that means a node must have logged something at least once in order to be able to change its level; is there a good way in the UI that we could set the level for a node that has never logged anything?~~