### PR TITLE
Add kinetic and lunar and simplify CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,14 @@
-sudo: required 
-dist: trusty 
-language: generic 
-compiler:
-  - gcc
 notifications:
   email:
     on_success: always
     on_failure: always
-#    recipients:
-#      - jane@doe
 env:
   matrix:
-    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - USE_DEB=true  ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-matrix:
-  allow_failures:
-    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="indigo"  USE_DEB="true"
+    - ROS_DISTRO="jade"    USE_DEB="true"
+    - ROS_DISTRO="kinetic" USE_DEB="true"
+    - ROS_DISTRO="lunar"   USE_DEB="true" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 dist: trusty
 notifications:
   email:


### PR DESCRIPTION
- Remove cruft from CI configuration
- Add ROS kinetic to CI configuration
- Add ROS lunar to CI configuration
- Remove shadow-fixed builds from CI configuration. Since this repository has very few catkin dependencies, there's no reason to build for both shadow-fixed and released.