### PR TITLE
Update CI--deprecate Jade, update Lunar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ notifications:
 env:
   matrix:
     - ROS_DISTRO="indigo"  USE_DEB="true"
-    - ROS_DISTRO="jade"    USE_DEB="true"
     - ROS_DISTRO="kinetic" USE_DEB="true"
-    - ROS_DISTRO="lunar"   USE_DEB="true" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar"   USE_DEB="true"
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 


### PR DESCRIPTION
Deprecate Jade, which no longer builds, and update Lunar to build against the released dependencies.