### PR TITLE
Fixed loglevel masking (for ROS2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(UI_FILES
   ui/console_window.ui)
 set(HEADER_FILES
   include/swri_console/bag_reader.h
+  include/swri_console/defines.h
   include/swri_console/console_master.h
   include/swri_console/console_window.h
   include/swri_console/log_database.h

--- a/include/swri_console/defines.h
+++ b/include/swri_console/defines.h
@@ -1,0 +1,14 @@
+#ifndef SWRI_CONSOLE_DEFINES_H_
+#define SWRI_CONSOLE_DEFINES_H_
+
+#include <rcl_interfaces/msg/log.hpp>
+
+namespace LogLevelMask {
+  const uint8_t DEBUG = 0x01;
+  const uint8_t INFO = 0x02;
+  const uint8_t WARN = 0x04;
+  const uint8_t ERROR = 0x08;
+  const uint8_t FATAL = 0x10;
+};
+
+#endif // DEFINES_H

--- a/include/swri_console/log_database.h
+++ b/include/swri_console/log_database.h
@@ -45,13 +45,31 @@ namespace swri_console
 struct LogEntry
 {
   rclcpp::Time stamp;
-  uint8_t level;  
-  std::string node;  
+  uint8_t level_mask;
+  std::string node;
   std::string file;
   std::string function;
   uint32_t line;
   QStringList text;
   uint32_t seq;
+
+  void setLogLvl(uint8_t ros_log_lvl)
+  {
+    level = ros_log_lvl;
+    switch (ros_log_lvl) {
+      case rcl_interfaces::msg::Log::DEBUG : level_mask = 0x01; break;
+      case rcl_interfaces::msg::Log::INFO : level_mask = 0x02; break;
+      case rcl_interfaces::msg::Log::WARN : level_mask = 0x04; break;
+      case rcl_interfaces::msg::Log::ERROR : level_mask = 0x08; break;
+      case rcl_interfaces::msg::Log::FATAL : level_mask = 0x10; break;
+      default: level_mask = 0x01; break;
+    }
+  }
+
+  uint8_t getLogLvl(void) const { return level; }
+
+private:
+  uint8_t level;
 };
 
 class LogDatabase : public QObject

--- a/src/console_window.cpp
+++ b/src/console_window.cpp
@@ -42,6 +42,7 @@
 #include <swri_console/log_database_proxy_model.h>
 #include <swri_console/node_list_model.h>
 #include <swri_console/settings_keys.h>
+#include <swri_console/defines.h>
 
 #include <QColorDialog>
 #include <QRegExp>
@@ -271,19 +272,19 @@ void ConsoleWindow::setSeverityFilter()
   uint8_t mask = 0;
 
   if (ui.checkDebug->isChecked()) {
-    mask |= rcl_interfaces::msg::Log::DEBUG;
+    mask |= LogLevelMask::DEBUG;
   }
   if (ui.checkInfo->isChecked()) {
-    mask |= rcl_interfaces::msg::Log::INFO;
+    mask |= LogLevelMask::INFO;
   }
   if (ui.checkWarn->isChecked()) {
-    mask |= rcl_interfaces::msg::Log::WARN;
+    mask |= LogLevelMask::WARN;
   }
   if (ui.checkError->isChecked()) {
-    mask |= rcl_interfaces::msg::Log::ERROR;
+    mask |= LogLevelMask::ERROR;
   }
   if (ui.checkFatal->isChecked()) {
-    mask |= rcl_interfaces::msg::Log::FATAL;
+    mask |= LogLevelMask::FATAL;
   }
 
   QSettings settings;

--- a/src/log_database.cpp
+++ b/src/log_database.cpp
@@ -58,7 +58,7 @@ void LogDatabase::queueMessage(const rcl_interfaces::msg::Log::ConstSharedPtr ms
 
   LogEntry log;
   log.stamp = stamp_time;
-  log.level = msg->level;
+  log.setLogLvl(msg->level);
   log.node = msg->name;
   log.file = msg->file;
   log.function = msg->function;

--- a/src/log_database_proxy_model.cpp
+++ b/src/log_database_proxy_model.cpp
@@ -362,15 +362,15 @@ QVariant LogDatabaseProxyModel::data(
 
   if (role == Qt::DisplayRole) {
     char level = '?';
-    if (item.level == rcl_interfaces::msg::Log::DEBUG) {
+    if (item.getLogLvl() == rcl_interfaces::msg::Log::DEBUG) {
       level = 'D';
-    } else if (item.level == rcl_interfaces::msg::Log::INFO) {
+    } else if (item.getLogLvl() == rcl_interfaces::msg::Log::INFO) {
       level = 'I';
-    } else if (item.level == rcl_interfaces::msg::Log::WARN) {
+    } else if (item.getLogLvl() == rcl_interfaces::msg::Log::WARN) {
       level = 'W';
-    } else if (item.level == rcl_interfaces::msg::Log::ERROR) {
+    } else if (item.getLogLvl() == rcl_interfaces::msg::Log::ERROR) {
       level = 'E';
-    } else if (item.level == rcl_interfaces::msg::Log::FATAL) {
+    } else if (item.getLogLvl() == rcl_interfaces::msg::Log::FATAL) {
       level = 'F';
     }
 
@@ -416,7 +416,7 @@ QVariant LogDatabaseProxyModel::data(
     return QVariant(QString(header) + item.text[line_idx.line_index]);
   }
   else if (role == Qt::ForegroundRole && colorize_logs_) {
-    switch (item.level) {
+    switch (item.getLogLvl()) {
       case rcl_interfaces::msg::Log::DEBUG:
         return QVariant(debug_color_);
       case rcl_interfaces::msg::Log::INFO:
@@ -671,7 +671,7 @@ void LogDatabaseProxyModel::scheduleIdleProcessing()
 
 bool LogDatabaseProxyModel::acceptLogEntry(const LogEntry &item)
 {
-  if (!(item.level & severity_mask_)) {
+  if (!(item.level_mask & severity_mask_)) {
     return false;
   }
   


### PR DESCRIPTION
Log level masking for ROS2 did not work as expected. It works now with ROS2 Foxy.

The fix was part of this PR: https://github.com/swri-robotics/swri_console/pull/35
