### PR TITLE
Enable closing via Ctrl-C from a terminal

### DIFF
--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -39,7 +39,8 @@ RosThread::RosThread(int argc, char** argv) :
 {
   ros::init(argc, argv, "swri_console",
             ros::init_options::AnonymousName |
-            ros::init_options::NoRosout);
+            ros::init_options::NoRosout |
+            ros::init_options::NoSigintHandler);
 }
 
 void RosThread::run()


### PR DESCRIPTION
This was done by telling ros::init to not create signal handlers. 