### PR TITLE
Replace deprecated is_initialized() with ok()

### DIFF
--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -48,7 +48,7 @@ void RosThread::run()
 {
   while (is_running_)
   {
-    bool is_initialized = rclcpp::is_initialized();
+    bool is_initialized = rclcpp::ok();
 
     if (!is_connected_ && is_initialized) {
       startRos();
@@ -66,7 +66,7 @@ void RosThread::run()
 void RosThread::shutdown()
 {
   is_running_ = false;
-  if (rclcpp::is_initialized())
+  if (rclcpp::ok())
   {
     rclcpp::shutdown();
   }


### PR DESCRIPTION
Perhaps `dashing-devel` isn't the best branch for this? But it's the only ROS2 branch present it seems.
This should fix [galactic](https://github.com/ros2/rclcpp/pull/1622/files#diff-40a81900d813b0824db3259f66b5667ca6684ba6c8d24d6a85b9f8904ef4e1a0L159).