### PR TITLE
Fix boost dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <build_depend>libqt5-opengl-dev</build_depend>
-  <depend>libboost-thread</depend>
+  <depend>libboost-thread-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>


### PR DESCRIPTION
Without the `-dev` this happens in a docker install:

```
Starting >>> swri_console
--- stderr: swri_console                         
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find Boost (missing: Boost_INCLUDE_DIR thread)
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.16/Modules/FindBoost.cmake:2179 (find_package_handle_standard_args)
  CMakeLists.txt:24 (find_package)


---
Failed   <<< swri_console [1.65s, exited with code 1]
```

In practice this package is probably installed due to other packages already. But it's good to keep the dependencies in order.