### PR TITLE
Fix: Changed rosout subsciption to use rcl_qos_profile_rosout_default…

### DIFF
--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -87,7 +87,8 @@ void RosThread::startRos()
 
   nh_ = rclcpp::Node::make_shared(name.str());
 
-  rosout_sub_ = nh_->create_subscription<rcl_interfaces::msg::Log>("/rosout", 100,
+  rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rcl_qos_profile_rosout_default));
+  rosout_sub_ = nh_->create_subscription<rcl_interfaces::msg::Log>("/rosout", qos,
       [this](rcl_interfaces::msg::Log::ConstSharedPtr msg) {
     Q_EMIT logReceived(std::move(msg));
   });


### PR DESCRIPTION
…. This should ensure that all logs are registered.

Note that I have only tested this in ROS2 Galactic.