### PR TITLE
Fix: Before maximum 1 log entry every 50 ms was processed. Now all en…

### DIFF
--- a/include/swri_console/ros_thread.h
+++ b/include/swri_console/ros_thread.h
@@ -71,6 +71,8 @@ namespace swri_console
     void startRos();
     void stopRos();
 
+    void emptyLogQueue(rcl_interfaces::msg::Log::ConstSharedPtr msg);
+
     bool is_connected_;
     volatile bool is_running_;
 


### PR DESCRIPTION
Before maximum 1 log entry every 50 ms was processed. With this PR, the /rosout queue is emptied every 50ms and all entries are processed.

I'm not sure if this is the most elegant solution, but it works in ROS2 Galactic.