### PR TITLE
Switching to system default QoS

### DIFF
--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -87,7 +87,7 @@ void RosThread::startRos()
 
   nh_ = rclcpp::Node::make_shared(name.str());
 
-  rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rcl_qos_profile_rosout_default));
+  rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_system_default));
 
   rosout_sub_ = nh_->create_subscription<rcl_interfaces::msg::Log>(
     "/rosout", qos, std::bind(&RosThread::emptyLogQueue, this, std::placeholders::_1));


### PR DESCRIPTION
The current QoS profile isn't defined any more in Foxy and newer distros. This switches it to the default system QoS profile.