### PR TITLE
Update Qt Flags

### DIFF
--- a/src/console_window.cpp
+++ b/src/console_window.cpp
@@ -55,6 +55,14 @@
 #include <QMenu>
 #include <QSettings>
 
+// QString::SkipEmptyParts was deprecated in favor of Qt::SkipEmptyParts in
+// Qt 5.14.0
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+  #define SPLIT_FLAG (Qt::SkipEmptyParts)
+#else
+  #define SPLIT_FLAG (QString::SkipEmptyParts)
+#endif
+
 using namespace Qt;
 
 namespace swri_console {
@@ -267,7 +275,7 @@ void ConsoleWindow::nodeSelectionChanged()
   db_proxy_->setNodeFilter(nodes);
 
   for (int i = 0; i < node_names.size(); i++) {
-    node_names[i] = node_names[i].split("/", Qt::SkipEmptyParts).last();
+    node_names[i] = node_names[i].split("/", SPLIT_FLAG).last();
   }
     
   setWindowTitle(QString("SWRI Console (") + node_names.join(", ") + ")");
@@ -386,7 +394,7 @@ void ConsoleWindow::setFollowNewest(bool follow)
 
 void ConsoleWindow::includeFilterUpdated(const QString &text)
 {
-  QStringList items = text.split(";", Qt::SkipEmptyParts);
+  QStringList items = text.split(";", SPLIT_FLAG);
   QStringList filtered;
   
   for (int i = 0; i < items.size(); i++) {
@@ -404,7 +412,7 @@ void ConsoleWindow::includeFilterUpdated(const QString &text)
 
 void ConsoleWindow::excludeFilterUpdated(const QString &text)
 {
-  QStringList items = text.split(";", Qt::SkipEmptyParts);
+  QStringList items = text.split(";", SPLIT_FLAG);
   QStringList filtered;
   
   for (int i = 0; i < items.size(); i++) {

--- a/src/console_window.cpp
+++ b/src/console_window.cpp
@@ -267,7 +267,7 @@ void ConsoleWindow::nodeSelectionChanged()
   db_proxy_->setNodeFilter(nodes);
 
   for (int i = 0; i < node_names.size(); i++) {
-    node_names[i] = node_names[i].split("/", QString::SkipEmptyParts).last();
+    node_names[i] = node_names[i].split("/", Qt::SkipEmptyParts).last();
   }
     
   setWindowTitle(QString("SWRI Console (") + node_names.join(", ") + ")");
@@ -386,7 +386,7 @@ void ConsoleWindow::setFollowNewest(bool follow)
 
 void ConsoleWindow::includeFilterUpdated(const QString &text)
 {
-  QStringList items = text.split(";", QString::SkipEmptyParts);
+  QStringList items = text.split(";", Qt::SkipEmptyParts);
   QStringList filtered;
   
   for (int i = 0; i < items.size(); i++) {
@@ -404,7 +404,7 @@ void ConsoleWindow::includeFilterUpdated(const QString &text)
 
 void ConsoleWindow::excludeFilterUpdated(const QString &text)
 {
-  QStringList items = text.split(";", QString::SkipEmptyParts);
+  QStringList items = text.split(";", Qt::SkipEmptyParts);
   QStringList filtered;
   
   for (int i = 0; i < items.size(); i++) {


### PR DESCRIPTION
Qt deprecated flags used to control the string splitting behavior. This conditionally uses the new flags for new versions of Qt.