### PR TITLE
Fix rosout subscription QoS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,13 @@ find_package(Qt5Widgets REQUIRED)
 
 find_package(Boost COMPONENTS thread REQUIRED)
 
+### Compile flag to support different versions of ROS ###
+if($ENV{ROS_DISTRO} STREQUAL "foxy")
+  set(USE_NEW_QOS_DEFN 0)
+else()
+  set(USE_NEW_QOS_DEFN 1)
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include_directories(include)

--- a/include/swri_console/ros_thread.h
+++ b/include/swri_console/ros_thread.h
@@ -71,6 +71,7 @@ namespace swri_console
     void startRos();
     void stopRos();
 
+    rclcpp::QoS getQos();
     void emptyLogQueue(rcl_interfaces::msg::Log::ConstSharedPtr msg);
 
     bool is_connected_;

--- a/src/ros_thread.cpp
+++ b/src/ros_thread.cpp
@@ -33,9 +33,10 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
 
-using namespace swri_console;
-
 using namespace std::literals::chrono_literals;
+
+namespace swri_console
+{
 
 RosThread::RosThread(int argc, char** argv) :
   is_connected_(false),
@@ -87,10 +88,10 @@ void RosThread::startRos()
 
   nh_ = rclcpp::Node::make_shared(name.str());
 
-  rclcpp::QoS qos(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_system_default));
-
   rosout_sub_ = nh_->create_subscription<rcl_interfaces::msg::Log>(
-    "/rosout", qos, std::bind(&RosThread::emptyLogQueue, this, std::placeholders::_1));
+    "/rosout",
+    getQos(),
+    std::bind(&RosThread::emptyLogQueue, this, std::placeholders::_1));
 
   Q_EMIT connected(true);
 }
@@ -116,4 +117,21 @@ void RosThread::emptyLogQueue(rcl_interfaces::msg::Log::ConstSharedPtr msg)
     }
     Q_EMIT logReceived(std::move(m_ptr));
   }
+}
+
+rclcpp::QoS RosThread::getQos()
+{
+#if USE_NEW_QOS_DEFN == 0
+  // Foxy does not have a defined QoS profile, so we copy the initialization from
+  // rclc/logging_rosout.c
+  auto qos_profile = rmw_qos_profile_default;
+  qos_profile.depth = 1000;
+  qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  qos_profile.lifespan.sec = 10;
+  qos_profile.lifespan.nsec = 0;
+  return rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile));
+#else
+  return rclcpp::QoSInitialization::from_rmw(rcl_qos_profile_rosout_default);
+#endif
+}
 }


### PR DESCRIPTION
I noticed that some messages published on `/rosout` were not being shown in swri_console. I looked into the QOS settings of the subscription to `/rosout` and found two differences to the [default rosout publishing qos](https://github.com/ros2/rcl/blob/fcabfaca94809627aefc1bd1c290e2a07a859492/rcl/include/rcl/logging_rosout.h#L37)

```
Node name: swri_console_1676460013745922475
Node namespace: /
Topic type: rcl_interfaces/msg/Log
Endpoint type: SUBSCRIPTION
GID: 01.10.27.e5.f4.89.02.45.d0.cb.9c.2f.00.00.15.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```

The differences are in the History Depth and the Durability.

This PR fixes the QoS such that the all the messages on /rosout are well received.

For confirmation, this is the same QoS profile that [foxglove](https://foxglove.dev/) uses:

With this PR:

```
Subscription count: 2

Node name: swri_console_1676460393616757708
Node namespace: /
Topic type: rcl_interfaces/msg/Log
Endpoint type: SUBSCRIPTION
GID: 01.10.3a.24.2a.0a.bb.55.d8.3f.22.dc.00.00.15.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: foxglove_bridge
Node namespace: /
Topic type: rcl_interfaces/msg/Log
Endpoint type: SUBSCRIPTION
GID: 01.10.ab.2a.e6.2a.74.2a.65.cf.20.52.00.00.2d.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```