### PR TITLE
Fix: "Human readable time" now shows milliseconds correctly.

### DIFF
--- a/src/log_database_proxy_model.cpp
+++ b/src/log_database_proxy_model.cpp
@@ -429,7 +429,7 @@ QVariant LogDatabaseProxyModel::data(
       if (human_readable_time_) {
         char date_str[std::size("yyyy-mm-dd hh:mm:ss")];
         const time_t time = static_cast<time_t>(item.stamp.seconds());
-        int32_t milliseconds = static_cast<int>(1000.0 * (item.stamp.seconds() - static_cast<double>(item.stamp.seconds())));
+        int32_t milliseconds = static_cast<int>(1000.0 * (item.stamp.seconds() - std::floor(item.stamp.seconds())));
         std::strftime(std::data(date_str),
           std::size(date_str),
           "%F %T",


### PR DESCRIPTION
Before this fix, all log lines were shown with "000" milliseconds when "Use human readable time" was enabled. Now they are shown correctly.