### PR TITLE
Fix bag reading

### DIFF
--- a/src/bag_reader.cpp
+++ b/src/bag_reader.cpp
@@ -30,6 +30,8 @@
 
 #include <QFileDialog>
 #include <QDir>
+#include <QDebug>
+#include <QFileInfo>
 #include <QMessageBox>
 
 #include "swri_console/bag_reader.h"
@@ -60,6 +62,7 @@ void BagReader::readBagFile(const QString& filename)
     emit logReceived(log);
   }
 
+  qInfo() << "Finished reading " << filename;
   emit finishedReading();
 }
 
@@ -68,10 +71,12 @@ void BagReader::promptForBagFile()
   QString filename = QFileDialog::getOpenFileName(nullptr,
                                                   tr("Open Bag File"),
                                                   QDir::homePath(),
-                                                  tr("Bag Files (*.mcap)"));
+                                                  tr("Bag Files (*.mcap *.db3)"));
 
   if (filename != nullptr)
   {
-    readBagFile(filename);
+    QString bagDir = QFileInfo(filename).dir().absolutePath();
+    qInfo() << "Reading bag directory:" << bagDir;
+    readBagFile(bagDir);
   }
 }

--- a/src/bag_reader.cpp
+++ b/src/bag_reader.cpp
@@ -44,7 +44,15 @@ void BagReader::readBagFile(const QString& filename)
   rosbag2_storage::StorageOptions storage_options;
   storage_options.uri = filename.toStdString();
   auto reader = rosbag2_transport::ReaderWriterFactory::make_reader(storage_options);
-  reader->open(storage_options);
+  try
+  {
+    reader->open(storage_options);
+  }
+  catch (const std::runtime_error& e)
+  {
+    qCritical() << "Bag " << filename << " failed to open with error: " << e.what();
+    return;
+  }
 
   while (reader->has_next()) {
     auto msg = reader->read_next();
@@ -77,6 +85,12 @@ void BagReader::promptForBagFile()
   {
     QString bagDir = QFileInfo(filename).dir().absolutePath();
     qInfo() << "Reading bag directory:" << bagDir;
+
+    if (!QFileInfo::exists(bagDir + "/metadata.yaml"))
+    {
+      qWarning() << "Bag directory " << bagDir << " does not contain metadata.yaml. Reading may fail.";
+    }
+
     readBagFile(bagDir);
   }
 }


### PR DESCRIPTION
The `rosbag2_cpp::Reader` used to parse bags in bag_reader.cpp expects to parse the `metadata.yaml` file associated w/ the input ros bag. We're currently just passing the path directly to the .mcap file selected in `promptForBagFile`, which does not allow the reader to properly find the metadata.

This change adds the ability to select both .mcap and .db3 (sqlite) bags and passes the parent directory of the selected file to the `readBagFile` function so the reader can search for the backend agnostic metadata.yaml file. I've also added some logging and failure checks around reading bags w/out metadata to be a bit more robust.