### PR TITLE
Typing an exclude term now highlights matching log rows instead of hi…

### DIFF
--- a/include/swri_console/console_window.h
+++ b/include/swri_console/console_window.h
@@ -78,7 +78,7 @@ class ConsoleWindow : public QMainWindow {
   void userScrolled(int);
 
   void includeFilterUpdated(const QString &);
-  void excludeFilterUpdated(const QString &);
+  void excludeTextEdited();
   void searchIndex();  // VM 4/13/2017
   void updateIncludeLabel();
   void updateExcludeLabel();

--- a/include/swri_console/log_database_proxy_model.h
+++ b/include/swri_console/log_database_proxy_model.h
@@ -65,6 +65,7 @@ class LogDatabaseProxyModel : public QAbstractListModel
   void setExcludeFilters(const QStringList &list);
   void setIncludeRegexpPattern(const QString& pattern);
   void setExcludeRegexpPattern(const QString& pattern);
+  void setExcludePreviewFilter(const QString& term);
   void setDebugColor(const QColor& debug_color);
   void setInfoColor(const QColor& info_color);
   void setWarnColor(const QColor& warn_color);
@@ -105,6 +106,7 @@ class LogDatabaseProxyModel : public QAbstractListModel
   
   bool acceptLogEntry(const LogEntry &item);
   bool testIncludeFilter(const LogEntry &item);
+  bool matchesExcludePreview(const LogEntry &item) const;
   
   std::set<std::string> names_;
   uint8_t severity_mask_;
@@ -138,6 +140,12 @@ class LogDatabaseProxyModel : public QAbstractListModel
   QRegularExpression exclude_regexp_;
   QStringList include_strings_;
   QStringList exclude_strings_;
+
+  // The exclude term currently being typed (not yet committed to
+  // exclude_strings_/exclude_regexp_).  Matching rows are highlighted
+  // rather than filtered out until the term is committed.
+  QString exclude_preview_term_;
+  QRegularExpression exclude_preview_regexp_;
 
   QColor debug_color_;
   QColor info_color_;

--- a/src/console_window.cpp
+++ b/src/console_window.cpp
@@ -193,7 +193,16 @@ ConsoleWindow::ConsoleWindow(LogDatabase *db)
 
   QObject::connect(
     ui.excludeText, SIGNAL(textChanged(const QString &)),
-    this, SLOT(excludeFilterUpdated(const QString &)));
+    this, SLOT(excludeTextEdited()));
+  QObject::connect(
+    ui.excludeText, SIGNAL(cursorPositionChanged(int, int)),
+    this, SLOT(excludeTextEdited()));
+  QObject::connect(
+    ui.excludeText, SIGNAL(editingFinished()),
+    this, SLOT(excludeTextEdited()));
+  QObject::connect(
+    ui.action_RegularExpressions, SIGNAL(toggled(bool)),
+    this, SLOT(excludeTextEdited()));
 
   // Connect 'Search' text modification to searchIndex, VCM 13 April 2017
   QObject::connect(
@@ -410,20 +419,60 @@ void ConsoleWindow::includeFilterUpdated(const QString &text)
   updateIncludeLabel();
 }
 
-void ConsoleWindow::excludeFilterUpdated(const QString &text)
+void ConsoleWindow::excludeTextEdited()
 {
-  QStringList items = text.split(";", Qt::SkipEmptyParts);
-  QStringList filtered;
-  
-  for (int i = 0; i < items.size(); i++) {
-    QString x = items[i].trimmed();
-    if (!x.isEmpty()) {
-      filtered.append(x);
+  QString text = ui.excludeText->text();
+  bool editing = ui.excludeText->hasFocus();
+
+  if (ui.action_RegularExpressions->isChecked()) {
+    // There's no natural way to split a single regexp into "committed" and
+    // "in progress" pieces, so treat the whole pattern as a preview while
+    // the field has focus, and only commit it as an active filter once the
+    // user moves on (matches the plain-string behavior below).
+    if (editing) {
+      db_proxy_->setExcludePreviewFilter(text);
+    } else {
+      db_proxy_->setExcludeRegexpPattern(text);
+      db_proxy_->setExcludePreviewFilter(QString());
     }
+  } else {
+    QString pending;
+    QString committedText = text;
+
+    if (editing) {
+      int cursor = ui.excludeText->cursorPosition();
+
+      // QString::lastIndexOf(ch, -1) means "search from the end", so guard
+      // the cursor == 0 case explicitly rather than passing cursor - 1 == -1
+      // and getting a match from the wrong end of the string.
+      int start = 0;
+      if (cursor > 0) {
+        int prevSemicolon = text.lastIndexOf(';', cursor - 1);
+        start = (prevSemicolon == -1) ? 0 : prevSemicolon + 1;
+      }
+
+      int end = text.indexOf(';', cursor);
+      if (end == -1) {
+        end = text.length();
+      }
+      pending = text.mid(start, end - start).trimmed();
+      committedText.remove(start, end - start);
+    }
+
+    QStringList items = committedText.split(";", Qt::SkipEmptyParts);
+    QStringList filtered;
+
+    for (int i = 0; i < items.size(); i++) {
+      QString x = items[i].trimmed();
+      if (!x.isEmpty()) {
+        filtered.append(x);
+      }
+    }
+
+    db_proxy_->setExcludeFilters(filtered);
+    db_proxy_->setExcludePreviewFilter(pending);
   }
 
-  db_proxy_->setExcludeFilters(filtered);
-  db_proxy_->setExcludeRegexpPattern(text);
   db_proxy_->clearSearchFailure();  // resets failed search variables, VCM 27 April 2017
   updateExcludeLabel();
 }

--- a/src/log_database_proxy_model.cpp
+++ b/src/log_database_proxy_model.cpp
@@ -238,6 +238,23 @@ void LogDatabaseProxyModel::setExcludeRegexpPattern(const QString& pattern)
   reset();
 }
 
+void LogDatabaseProxyModel::setExcludePreviewFilter(const QString& term)
+{
+  if (use_regular_expressions_) {
+    exclude_preview_regexp_.setPattern(term);
+    exclude_preview_term_.clear();
+  } else {
+    exclude_preview_term_ = term;
+    exclude_preview_regexp_.setPattern(QString());
+  }
+
+  // The preview never changes which rows are accepted, so there's no need
+  // to rebuild msg_mapping_ via reset(); just repaint the affected rows.
+  if (rowCount(QModelIndex()) > 0) {
+    Q_EMIT dataChanged(index(0), index(rowCount(QModelIndex()) - 1), {Qt::BackgroundRole});
+  }
+}
+
 void LogDatabaseProxyModel::setDebugColor(const QColor& debug_color)
 {
   debug_color_ = debug_color;
@@ -299,6 +316,9 @@ bool LogDatabaseProxyModel::isIncludeValid() const
 bool LogDatabaseProxyModel::isExcludeValid() const
 {
   if (use_regular_expressions_ && !exclude_regexp_.isValid()) {
+    return false;
+  }
+  if (use_regular_expressions_ && !exclude_preview_regexp_.isValid()) {
     return false;
   }
   return true;
@@ -399,6 +419,12 @@ QVariant LogDatabaseProxyModel::data(
       if (colorize_logs_) {
         break;
       }
+      return QVariant();
+    case Qt::BackgroundRole:
+      if (!exclude_preview_term_.isEmpty() || !exclude_preview_regexp_.pattern().isEmpty()) {
+        break;
+      }
+      return QVariant();
     default:
       return QVariant();
   }
@@ -494,6 +520,12 @@ QVariant LogDatabaseProxyModel::data(
     }
 
     return QVariant(QString(header) + item.text[line_idx.line_index]);
+  }
+  else if (role == Qt::BackgroundRole) {
+    if (matchesExcludePreview(item)) {
+      return QVariant(QColor(255, 210, 130));
+    }
+    return QVariant();
   }
   else if (role == Qt::ForegroundRole && colorize_logs_) {
     switch (item.getLogLvl()) {
@@ -785,6 +817,20 @@ bool LogDatabaseProxyModel::acceptLogEntry(const LogEntry &item)
   }
 
   return true;
+}
+
+// Return true if the item matches the exclude term currently being typed
+// (but not yet committed).  Used to highlight rows instead of hiding them
+// while the user is still composing the term.
+bool LogDatabaseProxyModel::matchesExcludePreview(const LogEntry &item) const
+{
+  if (use_regular_expressions_) {
+    return !exclude_preview_regexp_.pattern().isEmpty() &&
+      exclude_preview_regexp_.match(item.text.join(" ")).hasMatch();
+  }
+
+  return !exclude_preview_term_.isEmpty() &&
+    item.text.join(" ").contains(exclude_preview_term_, Qt::CaseInsensitive);
 }
 
 // Return true if the item message contains at least one of the


### PR DESCRIPTION
…ding them, and only starts actually filtering once the user moves to the next term or shift focus away.